### PR TITLE
zfc-admin already in composer.json of the sub package speck-catalog

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -88,7 +88,6 @@
         "speckcommerce/speck-order"           : "dev-master",
         "speckcommerce/speck-multisite"       : "dev-master",
         "evandotpro/edp-sub-layout"           : "dev-master",
-        "zf-commons/zfc-admin"                : "dev-master",
         "rwoverdijk/assetmanager"             : "dev-master",
         "atukai/at-php-settings"              : "dev-master"
     }


### PR DESCRIPTION
Cause an error on composer.phar
