### PR TITLE
Remove closure from cacheable config file

### DIFF
--- a/config/autoload/database.local.php.dist
+++ b/config/autoload/database.local.php.dist
@@ -12,13 +12,6 @@ return array(
         'factories' => array(
             'Zend\Db\Adapter\Adapter' => 'Zend\Db\Adapter\AdapterServiceFactory',
         ),
-        'initializers' => array(
-            function ($instance, $sm) {
-                if ($instance instanceof Zend\Db\Adapter\AdapterAwareInterface) {
-                    return $instance->setDbAdapter($sm->get('Zend\Db\Adapter\Adapter'));
-                }
-            }
-        ),
     ),
     'db' => array(
         'driver'         => 'pdo',


### PR DESCRIPTION
Do we really need that initializer? Convention is each module handles it's db dependency separately using aliases.
